### PR TITLE
fix: calibrate synthetic data to match real CLIF cohort benchmarks

### DIFF
--- a/synthetic_clif/generators/adt.py
+++ b/synthetic_clif/generators/adt.py
@@ -36,7 +36,7 @@ class ADTGenerator(BaseGenerator):
         "short_icu": ["ICU", "Ward"],
     }
 
-    FLOW_WEIGHTS = [0.35, 0.25, 0.15, 0.15, 0.10]
+    FLOW_WEIGHTS = [0.45, 0.30, 0.05, 0.05, 0.15]
 
     # CLIF 2.1.0 hospital types
     HOSPITAL_TYPES = ["academic", "community", "LTACH"]

--- a/synthetic_clif/generators/hospitalization.py
+++ b/synthetic_clif/generators/hospitalization.py
@@ -31,8 +31,8 @@ class HospitalizationGenerator(BaseGenerator):
         patients_df: pd.DataFrame,
         n_hospitalizations: int,
         reference_date: Optional[datetime] = None,
-        median_los_days: float = 5.0,
-        los_sigma: float = 0.8,
+        median_los_days: float = 7.0,
+        los_sigma: float = 0.9,
     ) -> pd.DataFrame:
         """Generate hospitalizations linked to patients.
 

--- a/synthetic_clif/generators/medications.py
+++ b/synthetic_clif/generators/medications.py
@@ -195,8 +195,8 @@ class MedicationContinuousGenerator(BaseGenerator):
         # Vasopressors: ~25% of ICU patients
         if self.rng.random() < 0.25 and los_hours >= 12:
             # Primary vasopressor (weighted selection)
-            primary_agents = ["norepinephrine", "epinephrine", "dopamine", "dobutamine"]
-            primary_weights = [0.70, 0.15, 0.10, 0.05]
+            primary_agents = ["norepinephrine", "phenylephrine", "epinephrine", "dopamine", "dobutamine"]
+            primary_weights = [0.60, 0.11, 0.12, 0.10, 0.07]
             primary_vaso = self.rng.choice(primary_agents, p=primary_weights)
             records.extend(
                 self._generate_infusion(

--- a/synthetic_clif/generators/patient.py
+++ b/synthetic_clif/generators/patient.py
@@ -44,7 +44,7 @@ class PatientGenerator(BaseGenerator):
     def generate(
         self,
         n_patients: int,
-        mortality_rate: float = 0.15,
+        mortality_rate: float = 0.258,
         reference_date: Optional[datetime] = None,
     ) -> pd.DataFrame:
         """Generate patient demographics.

--- a/synthetic_clif/generators/respiratory.py
+++ b/synthetic_clif/generators/respiratory.py
@@ -142,7 +142,7 @@ class RespiratoryGenerator(BaseGenerator):
         # ~40% need some oxygen, ~15% need mechanical ventilation
         initial_status = self.rng.choice(
             ["room_air", "nasal_cannula", "high_flow", "nippv", "imv"],
-            p=[0.45, 0.25, 0.10, 0.08, 0.12],
+            p=[0.25, 0.20, 0.12, 0.12, 0.31],
         )
 
         device_map = {
@@ -172,7 +172,7 @@ class RespiratoryGenerator(BaseGenerator):
 
         # Track device trajectory
         current_fio2 = self._get_initial_fio2(current_device)
-        improving = self.rng.random() < 0.7  # 70% improve over stay
+        improving = self.rng.random() < 0.55  # 55% improve over stay
 
         for ts in timestamps:
             # Check for tracheostomy
@@ -220,7 +220,7 @@ class RespiratoryGenerator(BaseGenerator):
         current_idx = device_hierarchy.index(current_device)
 
         # Small probability of change per time step
-        if self.rng.random() < 0.02:  # 2% chance
+        if self.rng.random() < 0.01:  # 1% chance
             if improving:
                 # Wean (go down the hierarchy)
                 if current_idx > 0:


### PR DESCRIPTION
Addresses issue #37 - synthetic data was not realistic enough for
research testing, yielding only 28 patients with prolonged intubation.

Changes calibrated against real CLIF cohort data:
- ICU encounter rate: 70% -> 90% (real: 90.6%)
- Mechanical ventilation rate: 12% -> 31% (real: 30.6%)
- Slower ventilator weaning (1% vs 2% per step, 55% vs 70% improving)
  to produce more prolonged intubation (>48h) cases
- Add phenylephrine to primary vasopressor selection at 11%
- Median hospital LOS: 5.0 -> 7.0 days, sigma 0.8 -> 0.9
- Hospital mortality rate: 15% -> 25.8% (real: 25.8%)

These changes should produce cohorts of 200-500+ patients for subgroup
analysis instead of the previous ~28.

https://claude.ai/code/session_01XRumyzGNT7MBAu5XYc8jYx