### PR TITLE
fix: rename peak_inspiratory_pressure to peak_inspiratory_pressure_set

### DIFF
--- a/synthetic_clif/config/schema.py
+++ b/synthetic_clif/config/schema.py
@@ -131,7 +131,7 @@ class CLIFSchema:
             ColumnSchema("pressure_control_set", "float64"),
             ColumnSchema("pressure_support_set", "float64"),
             ColumnSchema("flow_rate_set", "float64"),
-            ColumnSchema("peak_inspiratory_pressure", "float64"),
+            ColumnSchema("peak_inspiratory_pressure_set", "float64"),
             ColumnSchema("plateau_pressure", "float64"),
             ColumnSchema("peep_set", "float64"),
             ColumnSchema("ve_delivered", "float64"),


### PR DESCRIPTION
Fixes #42

Renames the `peak_inspiratory_pressure` column to `peak_inspiratory_pressure_set` in the `clif_respiratory_support` schema definition, aligning it with other set-point columns (`peep_set`, `resp_rate_set`, `pressure_support_set`, `fio2_set`, etc.) and with the `process_resp_support_waterfall.R` utility expectation.

Generated with [Claude Code](https://claude.ai/code)