### PR TITLE
docs: fix download version in README to v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ A pre-generated dataset with **10,000 hospitalizations** (~33 million rows acros
 
 ```bash
 # Download and extract (requires GitHub CLI)
-gh release download v0.4.0 -R AartikSarma/synthetic_clif -p "synth_clif_10k.tar.gz"
+gh release download v0.6.0 -R AartikSarma/synthetic_clif -p "synth_clif_10k.tar.gz"
 mkdir -p synth_clif_10k && tar -xzf synth_clif_10k.tar.gz -C synth_clif_10k
 
 # Or download directly
-curl -L https://github.com/AartikSarma/synthetic_clif/releases/download/v0.4.0/synth_clif_10k.tar.gz | tar -xz -C synth_clif_10k
+curl -L https://github.com/AartikSarma/synthetic_clif/releases/download/v0.6.0/synth_clif_10k.tar.gz | tar -xz -C synth_clif_10k
 ```
 
 Then load in Python:


### PR DESCRIPTION
Fixes #48

Updated download commands in Quick Start section of README.md from `v0.4.0` to `v0.6.0` to match the latest GitHub release tag.

Generated with [Claude Code](https://claude.ai/code)