### PR TITLE
fix: generate death_dttm within CLIF historical date range

### DIFF
--- a/synthetic_clif/generators/patient.py
+++ b/synthetic_clif/generators/patient.py
@@ -9,6 +9,7 @@ from faker import Faker
 
 from synthetic_clif.generators.base import BaseGenerator
 from synthetic_clif.config.mcide import MCIDELoader
+from synthetic_clif.generators.hospitalization import CLIF_DATE_START, CLIF_DATE_END
 
 
 class PatientGenerator(BaseGenerator):
@@ -106,10 +107,10 @@ class PatientGenerator(BaseGenerator):
         death_indices = self.rng.choice(n_patients, size=n_deaths, replace=False)
         death_dttms = [None] * n_patients
 
+        total_clif_seconds = int((CLIF_DATE_END - CLIF_DATE_START).total_seconds())
         for idx in death_indices:
-            # Death occurs within 0-90 days of reference date (will be linked to hospitalization)
-            days_until_death = int(self.rng.integers(0, 90))
-            death_dttms[idx] = reference_date - timedelta(days=days_until_death)
+            offset_seconds = int(self.rng.integers(0, total_clif_seconds))
+            death_dttms[idx] = CLIF_DATE_START + timedelta(seconds=offset_seconds)
 
         # Create DataFrame with columns ordered per CLIF 2.1.0 schema
         df = pd.DataFrame(

--- a/tests/test_hospitalization.py
+++ b/tests/test_hospitalization.py
@@ -77,3 +77,17 @@ class TestHospitalizationGenerator:
 
         hosp_counts = df.groupby("patient_id").size()
         assert hosp_counts.max() > 1  # At least one patient has multiple
+
+    def test_mortality_nonzero(self, seed, mcide):
+        """Test that Expired discharge category appears for patients with death dates."""
+        from synthetic_clif.generators.patient import PatientGenerator
+
+        pt_gen = PatientGenerator(seed=seed, mcide=mcide)
+        patients = pt_gen.generate(n_patients=200, mortality_rate=0.20)
+
+        gen = HospitalizationGenerator(seed=seed, mcide=mcide)
+        df = gen.generate(patients, n_hospitalizations=300)
+
+        assert (df["discharge_category"] == "Expired").any(), (
+            "Expected at least one 'Expired' discharge but found none"
+        )


### PR DESCRIPTION
Fixes #54

Death dates were generated relative to `datetime.now()` (~2026), but hospitalizations are drawn from 2018–2024. The `is_terminal` check could never fire, producing zero mortality events.

Generate death dates uniformly within CLIF_DATE_START–CLIF_DATE_END so they coincide with hospitalization windows. Adds regression test.

Generated with [Claude Code](https://claude.ai/code)